### PR TITLE
Updating interrupt tracking

### DIFF
--- a/EQLogParser/src/dao/DataManager.cs
+++ b/EQLogParser/src/dao/DataManager.cs
@@ -482,11 +482,12 @@ namespace EQLogParser
       Helpers.AddAction(AllHealBlocks, record, beginTime);
     }
 
-    internal void HandleSpellInterrupt(string player, string spell, double beginTime)
+    //THJ: Removed spell name requirement. Assuming this correctly flags player's last cast
+    internal void HandleSpellInterrupt(string player, double beginTime)
     {
       for (int i = AllSpellCastBlocks.Count - 1; i >= 0 && beginTime - AllSpellCastBlocks[i].BeginTime <= 5; i--)
       {
-        int index = AllSpellCastBlocks[i].Actions.FindLastIndex(action => action is SpellCast sc && sc.Spell == spell && sc.Caster == player);
+        int index = AllSpellCastBlocks[i].Actions.FindLastIndex(action => action is SpellCast sc && sc.Caster == player);
         if (index > -1 && AllSpellCastBlocks[i].Actions[index] is SpellCast cast)
         {
           cast.Interrupted = true;

--- a/EQLogParser/src/parsing/CastLineParser.cs
+++ b/EQLogParser/src/parsing/CastLineParser.cs
@@ -134,10 +134,6 @@ namespace EQLogParser
               var spellData = DataManager.Instance.GetSpellByName(spellName);
               DataManager.Instance.AddSpellCast(new SpellCast { Caster = player, Spell = string.Intern(spellName), SpellData = spellData, BeginTime = currentTime }, currentTime);
             }
-            else
-            {
-              DataManager.Instance.HandleSpellInterrupt(player, spellName, currentTime);
-            }
           }
         }
       }

--- a/EQLogParser/src/parsing/CastLineParser.cs
+++ b/EQLogParser/src/parsing/CastLineParser.cs
@@ -99,19 +99,24 @@ namespace EQLogParser
               }
             }
           }
-          else if (sList.Count > 4 && sList[sList.Count - 1] == "interrupted." && sList[sList.Count - 2] == "is" && sList[sList.Count - 3] == "spell")
+          //[Sun Jan 19 16:17:04 2025] Your spell is interrupted.
+          //[Sun Jan 19 16:27:49 2025] Zaxsvo's casting is interrupted!
+          //Since no spell name in interrupts, having faith this function correctly flags last added spell in AllSpellCastBlocks
+          else if (sList[3].Contains("interrupted"))
           {
             isInterrupted = true;
-            spellName = string.Join(" ", sList.ToArray(), 1, sList.Count - 4);
 
             if (sList[0] == "Your")
             {
-              player = ConfigUtil.PlayerName;
+                player = ConfigUtil.PlayerName;
             }
             else if (sList[0].Length > 3 && sList[0][sList[0].Length - 1] == 's' && sList[0][sList[0].Length - 2] == '\'')
             {
-              player = sList[0].Substring(0, sList[0].Length - 2);
+                player = sList[0].Substring(0, sList[0].Length - 2);
             }
+
+            double currentTime = lineData.BeginTime;
+            DataManager.Instance.HandleSpellInterrupt(player, currentTime);
           }
 
           if (!string.IsNullOrEmpty(player) && !string.IsNullOrEmpty(spellName))

--- a/EQLogParser/src/parsing/CastLineParser.cs
+++ b/EQLogParser/src/parsing/CastLineParser.cs
@@ -108,11 +108,11 @@ namespace EQLogParser
 
             if (sList[0] == "Your")
             {
-                player = ConfigUtil.PlayerName;
+              player = ConfigUtil.PlayerName;
             }
             else if (sList[0].Length > 3 && sList[0][sList[0].Length - 1] == 's' && sList[0][sList[0].Length - 2] == '\'')
             {
-                player = sList[0].Substring(0, sList[0].Length - 2);
+              player = sList[0].Substring(0, sList[0].Length - 2);
             }
 
             double currentTime = lineData.BeginTime;


### PR DESCRIPTION
Changes the check to match THJ interrupt message
Remove spell argument for HandleSpellInterupt
Assumes HandleSpellInterupt will correctly remove that player's last logged spell. Testing shows this to be effective so far. 