### PR TITLE
Duplicate doppel fix

### DIFF
--- a/EQLogParser/src/parsing/DamageLineParser.cs
+++ b/EQLogParser/src/parsing/DamageLineParser.cs
@@ -744,9 +744,8 @@ namespace EQLogParser
         }
 
         // Xan - specifically address Soandso's Celestial Hammer
-        // and Soandso`s doppelganger
         int iCH    = attacker.IndexOf( "`s Celestial Hammer" );
-        if ( iCH > -1)
+        if( iCH > -1 )
         {
             string  owner    = attacker.Substring( 0, iCH );
 
@@ -880,8 +879,8 @@ namespace EQLogParser
         part.Length >= (start + ++end) && part.Substring(start, 4) == "ward" && !(part.Length > (start + 5) && part[start + 5] != 'e') ||
         part.Length >= (start + ++end) && part.Substring(start, 5) == "Mount" ||
         part.Length >= (start + ++end) && (part.Substring(start, 6) == "warder" || part.Substring(start, 6) == "Warder") ||
+	part.Contains("doppelganger") ||
         // Xan - added for celestial hammer
-        part.Contains("doppelganger") ||
         part.Length >= (start + ++end) && part.Substring(start, 16) == "Celestial Hammer"
       )
       {

--- a/EQLogParser/src/parsing/DamageLineParser.cs
+++ b/EQLogParser/src/parsing/DamageLineParser.cs
@@ -746,11 +746,9 @@ namespace EQLogParser
         // Xan - specifically address Soandso's Celestial Hammer
         // and Soandso`s doppelganger
         int iCH    = attacker.IndexOf( "`s Celestial Hammer" );
-        int doppel = attacker.IndexOf("`s doppelganger");
-        if ( iCH > -1 || doppel > -1)
+        if ( iCH > -1)
         {
-            var customPet = iCH > -1 ? iCH : doppel;
-            string  owner    = attacker.Substring( 0, customPet );
+            string  owner    = attacker.Substring( 0, iCH );
 
             if( PlayerManager.Instance.IsVerifiedPlayer( owner ) )
             {

--- a/EQLogParser/src/parsing/DamageLineParser.cs
+++ b/EQLogParser/src/parsing/DamageLineParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -742,11 +742,15 @@ namespace EQLogParser
             }
             attacker    = pet;
         }
+
         // Xan - specifically address Soandso's Celestial Hammer
+        // and Soandso`s doppelganger
         int iCH    = attacker.IndexOf( "`s Celestial Hammer" );
-        if( iCH > -1 )
+        int doppel = attacker.IndexOf("`s doppelganger");
+        if ( iCH > -1 || doppel > -1)
         {
-            string  owner    = attacker.Substring( 0, iCH );
+            var customPet = iCH > -1 ? iCH : doppel;
+            string  owner    = attacker.Substring( 0, customPet );
 
             if( PlayerManager.Instance.IsVerifiedPlayer( owner ) )
             {
@@ -846,14 +850,7 @@ namespace EQLogParser
       bool hasOwner = false;
       owner = null;
 
-      // Xan the logic below this is kicking out custom THJ (enchanter) pet names, so short circuiting for known assigned pets
-      string    own = PlayerManager.Instance.GetPlayerFromPet( name );
-      if( !string.IsNullOrEmpty( own ) )
-      {
-        hasOwner    = true;
-        owner       = own;
-      }
-      else if (!string.IsNullOrEmpty(name))
+      if (!string.IsNullOrEmpty(name))
       {
         int pIndex = name.IndexOf("`s ", StringComparison.Ordinal);
         if ((pIndex > -1 && IsPetOrMount(name, pIndex + 3, out _)) || (pIndex = name.LastIndexOf(" pet", StringComparison.Ordinal)) > -1)
@@ -886,6 +883,7 @@ namespace EQLogParser
         part.Length >= (start + ++end) && part.Substring(start, 5) == "Mount" ||
         part.Length >= (start + ++end) && (part.Substring(start, 6) == "warder" || part.Substring(start, 6) == "Warder") ||
         // Xan - added for celestial hammer
+        part.Contains("doppelganger") ||
         part.Length >= (start + ++end) && part.Substring(start, 16) == "Celestial Hammer"
       )
       {


### PR DESCRIPTION
changed a bit of logic that i think was causing doppels to appear as npc entries. overall damage tracking shouldn't be different.